### PR TITLE
ESLint expects config modules to start `eslint-config-`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@ukhomeoffice/asl-eslint-common",
-  "version": "2.1.0",
+  "name": "@ukhomeoffice/eslint-config-asl",
+  "version": "2.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@ukhomeoffice/asl-eslint-common",
-      "version": "2.1.0",
+      "name": "@ukhomeoffice/eslint-config-asl",
+      "version": "2.2.1",
       "license": "MIT",
       "dependencies": {
         "eslint-config-semistandard": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@ukhomeoffice/asl-eslint-common",
-  "version": "2.2.0",
+  "name": "@ukhomeoffice/eslint-config-asl",
+  "version": "3.0.0",
   "description": "eslint configuration, extended out to asl code base.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
ESLint only accepts modules prefixed with `eslint-config` when loading config: [Creating a shareable config](https://eslint.org/docs/latest/extend/shareable-configs-deprecated#creating-a-shareable-config). This needs to be renamed so that we can reference it by module name. The previous workaround of referencing the reletive path of index.js doesn't work in `aspel-workspace` (and using the workspaces reletive path would be incorrect for linting in drone).

This change allows us to use `extends: ['@ukhomeoffice/asl']` which works in both scenarios.